### PR TITLE
Added recipes related to testing packages

### DIFF
--- a/ezsystems/behatbundle/8.3.x-dev/manifest.json
+++ b/ezsystems/behatbundle/8.3.x-dev/manifest.json
@@ -1,0 +1,13 @@
+{
+    "aliases": [],
+    "bundles": {
+        "FriendsOfBehat\\SymfonyExtension\\Bundle\\FriendsOfBehatSymfonyExtensionBundle": ["test", "behat"],
+        "EzSystems\\BehatBundle\\EzSystemsBehatBundle": ["behat"]
+    },
+    "copy-from-package": {
+        "behat_ibexa_oss.yaml": "behat_ibexa_oss.yaml",
+        "behat_ibexa_content.yaml": "behat_ibexa_content.yaml",
+        "behat_ibexa_experience.yaml": "behat_ibexa_experience.yaml",
+        "behat_ibexa_commerce.yaml": "behat_ibexa_commerce.yaml"
+    }
+}

--- a/ibexa/docker/0.1.x-dev/manifest.json
+++ b/ibexa/docker/0.1.x-dev/manifest.json
@@ -1,0 +1,41 @@
+{
+    "aliases": [],
+      "copy-from-package": {
+        "scripts/vhost.sh": "bin/vhost.sh",
+        "docker/": "doc/docker/",
+        "templates/apache2/": "doc/apache2/",
+        "templates/nginx/": "doc/nginx/"
+      },
+      "env": {
+        "#0": "Composer configuration on local:",
+        "COMPOSER_HOME": "~/.composer",
+        "#1": "# Docker Compose configuration",
+        "COMPOSE_FILE": "doc/docker/base-dev.yml",
+        "COMPOSE_DIR": ".",
+        "COMPOSE_PROJECT_NAME": "ibexa",
+        "PHP_IMAGE": "ezsystems/php:7.3-v2-node12",
+        "NGINX_IMAGE": "nginx:stable",
+        "MYSQL_IMAGE": "healthcheck/mariadb",
+        "REDIS_IMAGE": "healthcheck/redis",
+        "#2": "# Behat / Selenium config",
+        "#3": "## web host refer to the tip of the setup, so varnish if that is used.",
+        "SELENIUM_IMAGE": "selenium/standalone-chrome-debug:3.141.59-20200326",
+        "CHROMIUM_IMAGE": "registry.gitlab.com/dmore/docker-chrome-headless:7.1",
+        "WEB_HOST": "http://web",
+        "MINK_DEFAULT_SESSION": "selenium",
+        "SELENIUM_HOST": "http://selenium:4444/wd/hub",
+        "CHROMIUM_HOST": "http://chromium:9222",
+        "#4": "Database configuration for Docker",
+        "DATABASE_USER": "ezp",
+        "DATABASE_PASSWORD": "SetYourOwnPassword",
+        "DATABASE_NAME": "ezp",
+        "DATABASE_HOST": "db",
+        "DATABASE_PORT": "3306",
+        "DATABASE_PLATFORM": "mysql",
+        "DATABASE_DRIVER": "pdo_mysql",
+        "#5": "Needed by Doctrine Bundle / ORM to avoid it opening connection during situations where there is no service yet.",
+        "#6": "See: https://symfony.com/doc/current/reference/configuration/doctrine.html#doctrine-dbal-configuration",
+        "DATABASE_VERSION": "mariadb-10.3.0",
+        "DATABASE_URL": "${DATABASE_PLATFORM}://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}?serverVersion=${DATABASE_VERSION}"
+      }
+}


### PR DESCRIPTION
Added recipes for:
1) BehatBundle - which copies over our Behat configuration files
2) Docker - which copies the Docker Compose files (together with the scripts they need) and adds .env variables.

The recipes were previously added in https://github.com/webhdx/recipes and I've verified that they work on Travis here:
https://travis-ci.com/github/ezsystems/ezplatform-admin-ui/builds/211144857

They are not installed with the product by default.