### PR TITLE
[ibexa/{oss,content,experience,commerce}] Corrected instructions for installation

### DIFF
--- a/ibexa/commerce/dev-master/post-install.txt
+++ b/ibexa/commerce/dev-master/post-install.txt
@@ -18,9 +18,8 @@ To finish the installation process:
     2. Run the following commands:
        >  <comment>composer recipes:install ibexa/commerce --force</>
           <warning>This will overwrite some of the files.</warning> If you modified any of these reject and update manually.
-       >  <comment>php bin/console ezplatform:install ezplatform-ee-clean</>
-       >  <comment>php bin/console ezplatform:install ezcommerce-clean</>
-       >  <comment>php bin/console ezplatform:graphql:generate-schema</>
+       >  <comment>php bin/console ibexa:install</>
+       >  <comment>php bin/console ibexa:graphql:generate-schema</>
 
 Refer to https://doc.ibexa.co/en/latest/getting_started/install_ibexa_dxp for a detailed installation and configuration guide.
 <info>To get started working with Ibexa DXP, see First steps: https://doc.ibexa.co/en/latest/getting_started/first_steps.

--- a/ibexa/content/3.3.x-dev/post-install.txt
+++ b/ibexa/content/3.3.x-dev/post-install.txt
@@ -18,9 +18,8 @@ To finish the installation process:
     2. Run the following commands:
        >  <comment>composer recipes:install ibexa/content --force</>
           <warning>This will overwrite some of the files.</warning> If you modified any of these reject and update manually.
-       >  <comment>php bin/console ezplatform:install clean</>
-       >  <comment>php bin/console ezplatform:install ezcommerce-clean</>
-       >  <comment>php bin/console ezplatform:graphql:generate-schema</>
+       >  <comment>php bin/console ibexa:install</>
+       >  <comment>php bin/console ibexa:graphql:generate-schema</>
 
 Refer to https://doc.ibexa.co/en/latest/getting_started/install_ibexa_dxp for a detailed installation and configuration guide.
 <info>To get started working with Ibexa DXP, see First steps: https://doc.ibexa.co/en/latest/getting_started/first_steps.

--- a/ibexa/experience/3.3.x-dev/post-install.txt
+++ b/ibexa/experience/3.3.x-dev/post-install.txt
@@ -18,9 +18,8 @@ To finish the installation process:
     2. Run the following commands:
        >  <comment>composer recipes:install ibexa/experience --force</>
           <warning>This will overwrite some of the files.</warning> If you modified any of these reject and update manually.
-       >  <comment>php bin/console ezplatform:install ezplatform-ee-clean</>
-       >  <comment>php bin/console ezplatform:install ezcommerce-clean</>
-       >  <comment>php bin/console ezplatform:graphql:generate-schema</>
+       >  <comment>php bin/console ibexa:install</>
+       >  <comment>php bin/console ibexa:graphql:generate-schema</>
 
 Refer to https://doc.ibexa.co/en/latest/getting_started/install_ibexa_dxp for a detailed installation and configuration guide.
 <info>To get started working with Ibexa DXP, see First steps: https://doc.ibexa.co/en/latest/getting_started/first_steps.

--- a/ibexa/oss/3.3.x-dev/post-install.txt
+++ b/ibexa/oss/3.3.x-dev/post-install.txt
@@ -18,8 +18,8 @@ To finish the installation process:
     2. Run the following commands:
        >  <comment>composer recipes:install ibexa/oss --force</>
           <warning>This will overwrite some of the files.</warning> If you modified any of these reject and update manually.
-       >  <comment>php bin/console ezplatform:install clean</>
-       >  <comment>php bin/console ezplatform:graphql:generate-schema</>
+       >  <comment>php bin/console ibexa:install</>
+       >  <comment>php bin/console ibexa:graphql:generate-schema</>
 
 Refer to https://doc.ibexa.co/en/latest/getting_started/install_ibexa_dxp for a detailed installation and configuration guide.
 <fg=red>Visit https://www.ibexa.co to learn more about the benefits of using Ibexa DXP</>.


### PR DESCRIPTION
- after https://issues.ibexa.co/browse/EZP-32284 we can streamline the DB installation instructions displayed during flex installation.
- `ezplatform:graphql:generate-schema` command is now deprecated, `ibexa:graphql:generate-schema` should be used instead