### PR TITLE
[ibexa/oss] Changed encore:compile composer script to new alias

### DIFF
--- a/ibexa/commerce/dev-master/manifest.json
+++ b/ibexa/commerce/dev-master/manifest.json
@@ -163,6 +163,6 @@
     "assets:install %PUBLIC_DIR%": "symfony-cmd",
     "bazinga:js-translation:dump %PUBLIC_DIR%/assets --merge-domains": "symfony-cmd",
     "yarn install": "script",
-    "ezplatform:encore:compile": "symfony-cmd"
+    "ibexa:encore:compile": "symfony-cmd"
   }
 }

--- a/ibexa/content/3.3.x-dev/manifest.json
+++ b/ibexa/content/3.3.x-dev/manifest.json
@@ -140,6 +140,6 @@
     "assets:install %PUBLIC_DIR%": "symfony-cmd",
     "bazinga:js-translation:dump %PUBLIC_DIR%/assets --merge-domains": "symfony-cmd",
     "yarn install": "script",
-    "ezplatform:encore:compile": "symfony-cmd"
+    "ibexa:encore:compile": "symfony-cmd"
   }
 }

--- a/ibexa/experience/3.3.x-dev/manifest.json
+++ b/ibexa/experience/3.3.x-dev/manifest.json
@@ -146,6 +146,6 @@
     "assets:install %PUBLIC_DIR%": "symfony-cmd",
     "bazinga:js-translation:dump %PUBLIC_DIR%/assets --merge-domains": "symfony-cmd",
     "yarn install": "script",
-    "ezplatform:encore:compile": "symfony-cmd"
+    "ibexa:encore:compile": "symfony-cmd"
   }
 }

--- a/ibexa/oss/3.3.x-dev/manifest.json
+++ b/ibexa/oss/3.3.x-dev/manifest.json
@@ -87,6 +87,6 @@
     "assets:install %PUBLIC_DIR%": "symfony-cmd",
     "bazinga:js-translation:dump %PUBLIC_DIR%/assets --merge-domains": "symfony-cmd",
     "yarn install": "script",
-    "ezplatform:encore:compile": "symfony-cmd"
+    "ibexa:encore:compile": "symfony-cmd"
   }
 }


### PR DESCRIPTION
`ezplatform:*` commands are deprecated, we should use `ibexa:*` instead.