### PR TITLE
[ibexa/{oss,content,experience,commmerce}] Added info about Composer post-update-cmd to post-install message

### DIFF
--- a/ibexa/commerce/dev-master/post-install.txt
+++ b/ibexa/commerce/dev-master/post-install.txt
@@ -20,6 +20,7 @@ To finish the installation process:
           <warning>This will overwrite some of the files.</warning> If you modified any of these reject and update manually.
        >  <comment>php bin/console ibexa:install</>
        >  <comment>php bin/console ibexa:graphql:generate-schema</>
+       >  <comment>composer run post-update-cmd</>
 
 Refer to https://doc.ibexa.co/en/latest/getting_started/install_ibexa_dxp for a detailed installation and configuration guide.
 <info>To get started working with Ibexa DXP, see First steps: https://doc.ibexa.co/en/latest/getting_started/first_steps.

--- a/ibexa/content/3.3.x-dev/post-install.txt
+++ b/ibexa/content/3.3.x-dev/post-install.txt
@@ -20,6 +20,7 @@ To finish the installation process:
           <warning>This will overwrite some of the files.</warning> If you modified any of these reject and update manually.
        >  <comment>php bin/console ibexa:install</>
        >  <comment>php bin/console ibexa:graphql:generate-schema</>
+       >  <comment>composer run post-update-cmd</>
 
 Refer to https://doc.ibexa.co/en/latest/getting_started/install_ibexa_dxp for a detailed installation and configuration guide.
 <info>To get started working with Ibexa DXP, see First steps: https://doc.ibexa.co/en/latest/getting_started/first_steps.

--- a/ibexa/experience/3.3.x-dev/post-install.txt
+++ b/ibexa/experience/3.3.x-dev/post-install.txt
@@ -20,6 +20,7 @@ To finish the installation process:
           <warning>This will overwrite some of the files.</warning> If you modified any of these reject and update manually.
        >  <comment>php bin/console ibexa:install</>
        >  <comment>php bin/console ibexa:graphql:generate-schema</>
+       >  <comment>composer run post-update-cmd</>
 
 Refer to https://doc.ibexa.co/en/latest/getting_started/install_ibexa_dxp for a detailed installation and configuration guide.
 <info>To get started working with Ibexa DXP, see First steps: https://doc.ibexa.co/en/latest/getting_started/first_steps.

--- a/ibexa/oss/3.3.x-dev/post-install.txt
+++ b/ibexa/oss/3.3.x-dev/post-install.txt
@@ -20,6 +20,7 @@ To finish the installation process:
           <warning>This will overwrite some of the files.</warning> If you modified any of these reject and update manually.
        >  <comment>php bin/console ibexa:install</>
        >  <comment>php bin/console ibexa:graphql:generate-schema</>
+       >  <comment>composer run post-update-cmd</>
 
 Refer to https://doc.ibexa.co/en/latest/getting_started/install_ibexa_dxp for a detailed installation and configuration guide.
 <fg=red>Visit https://www.ibexa.co to learn more about the benefits of using Ibexa DXP</>.


### PR DESCRIPTION
Added information that `composer run post-update-cmd` should be run after the installation process.
Applies for 3.3.x-dev - recipe for 3.3.0 should remain unchanged.