### PR TITLE
[ibexa/*] Updated version of sass-loader

### DIFF
--- a/ibexa/commerce/3.3/encore/package.json
+++ b/ibexa/commerce/3.3/encore/package.json
@@ -9,7 +9,7 @@
     "webpack-notifier": "^1.6.0",
     "react-collapsible": "^2.5.0",
     "node-sass": "^4.11.0",
-    "sass-loader": "^7.0.1"
+    "sass-loader": "^9.0.1"
   },
   "license": "UNLICENSED",
   "private": true,

--- a/ibexa/commerce/dev-master/encore/package.json
+++ b/ibexa/commerce/dev-master/encore/package.json
@@ -9,7 +9,7 @@
     "webpack-notifier": "^1.6.0",
     "react-collapsible": "^2.5.0",
     "node-sass": "^4.11.0",
-    "sass-loader": "^7.0.1"
+    "sass-loader": "^9.0.1"
   },
   "license": "UNLICENSED",
   "private": true,

--- a/ibexa/content/3.3.x-dev/encore/package.json
+++ b/ibexa/content/3.3.x-dev/encore/package.json
@@ -9,7 +9,7 @@
     "webpack-notifier": "^1.6.0",
     "react-collapsible": "^2.5.0",
     "node-sass": "^4.11.0",
-    "sass-loader": "^7.0.1"
+    "sass-loader": "^9.0.1"
   },
   "license": "UNLICENSED",
   "private": true,

--- a/ibexa/content/3.3/encore/package.json
+++ b/ibexa/content/3.3/encore/package.json
@@ -9,7 +9,7 @@
     "webpack-notifier": "^1.6.0",
     "react-collapsible": "^2.5.0",
     "node-sass": "^4.11.0",
-    "sass-loader": "^7.0.1"
+    "sass-loader": "^9.0.1"
   },
   "license": "UNLICENSED",
   "private": true,

--- a/ibexa/experience/3.3.x-dev/encore/package.json
+++ b/ibexa/experience/3.3.x-dev/encore/package.json
@@ -9,7 +9,7 @@
     "webpack-notifier": "^1.6.0",
     "react-collapsible": "^2.5.0",
     "node-sass": "^4.11.0",
-    "sass-loader": "^7.0.1"
+    "sass-loader": "^9.0.1"
   },
   "license": "UNLICENSED",
   "private": true,

--- a/ibexa/experience/3.3/encore/package.json
+++ b/ibexa/experience/3.3/encore/package.json
@@ -9,7 +9,7 @@
     "webpack-notifier": "^1.6.0",
     "react-collapsible": "^2.5.0",
     "node-sass": "^4.11.0",
-    "sass-loader": "^7.0.1"
+    "sass-loader": "^9.0.1"
   },
   "license": "UNLICENSED",
   "private": true,

--- a/ibexa/oss/3.3.x-dev/encore/package.json
+++ b/ibexa/oss/3.3.x-dev/encore/package.json
@@ -8,7 +8,7 @@
     "regenerator-runtime": "^0.13.2",
     "webpack-notifier": "^1.6.0",
     "node-sass": "^4.11.0",
-    "sass-loader": "^7.0.1"
+    "sass-loader": "^9.0.1"
   },
   "license": "UNLICENSED",
   "private": true,

--- a/ibexa/oss/3.3/encore/package.json
+++ b/ibexa/oss/3.3/encore/package.json
@@ -8,7 +8,7 @@
     "regenerator-runtime": "^0.13.2",
     "webpack-notifier": "^1.6.0",
     "node-sass": "^4.11.0",
-    "sass-loader": "^7.0.1"
+    "sass-loader": "^9.0.1"
   },
   "license": "UNLICENSED",
   "private": true,


### PR DESCRIPTION
**Jira ticket: https://issues.ibexa.co/browse/EZP-32299**

Updated version of sass-loader from 7.x to 9.x as Webpack Encore requires 9.x.