### PR TITLE
EZEE-3474: standard pagelayout generator meta tag: eZ Platform → Ibexa DXP

### DIFF
--- a/ibexa/commerce/3.3/templates/themes/standard/pagelayout.html.twig
+++ b/ibexa/commerce/3.3/templates/themes/standard/pagelayout.html.twig
@@ -7,7 +7,7 @@
         {% set title = ez_content_name( content ) %}
     {% endif %}
     <title>{{ title|default( 'Home' ) }}</title>
-    <meta name="generator" content="eZ Platform"/>
+    <meta name="generator" content="Ibexa DXP"/>
     {% if content is defined and content.contentInfo.mainLocationId %}
         <link rel="canonical" href="{{ ez_path(content) }}" />
     {% endif %}

--- a/ibexa/content/3.3/templates/themes/standard/pagelayout.html.twig
+++ b/ibexa/content/3.3/templates/themes/standard/pagelayout.html.twig
@@ -7,7 +7,7 @@
         {% set title = ez_content_name( content ) %}
     {% endif %}
     <title>{{ title|default( 'Home' ) }}</title>
-    <meta name="generator" content="eZ Platform"/>
+    <meta name="generator" content="Ibexa DXP"/>
     {% if content is defined and content.contentInfo.mainLocationId %}
         <link rel="canonical" href="{{ ez_path(content) }}" />
     {% endif %}

--- a/ibexa/experience/3.3/templates/themes/standard/pagelayout.html.twig
+++ b/ibexa/experience/3.3/templates/themes/standard/pagelayout.html.twig
@@ -7,7 +7,7 @@
         {% set title = ez_content_name( content ) %}
     {% endif %}
     <title>{{ title|default( 'Home' ) }}</title>
-    <meta name="generator" content="eZ Platform"/>
+    <meta name="generator" content="Ibexa DXP"/>
     {% if content is defined and content.contentInfo.mainLocationId %}
         <link rel="canonical" href="{{ ez_path(content) }}" />
     {% endif %}

--- a/ibexa/oss/3.3/templates/themes/standard/pagelayout.html.twig
+++ b/ibexa/oss/3.3/templates/themes/standard/pagelayout.html.twig
@@ -7,7 +7,7 @@
         {% set title = ez_content_name( content ) %}
     {% endif %}
     <title>{{ title|default( 'Home' ) }}</title>
-    <meta name="generator" content="eZ Platform"/>
+    <meta name="generator" content="Ibexa DXP"/>
     {% if content is defined and content.contentInfo.mainLocationId %}
         <link rel="canonical" href="{{ ez_path(content) }}" />
     {% endif %}


### PR DESCRIPTION
| Question           | Answer
| ------------------ | ------------------
| **JIRA issue**     | [EZEE-3474](https://issues.ibexa.co/browse/EZEE-3474)
| **Type**           | Improvement/Misc
| **Target version** | master (3.3)
| **BC breaks**      | no
| **Doc needed**     | no

Update generator meta from eZ Platform to Ibexa DXP in default pagelayout from standard theme in

- [x] Open Source (oss)
- [x] Content
- [x] Experience
- [x] Commerce