### PR TITLE
[ezsystems/behatbundle] Added routing

### DIFF
--- a/ezsystems/behatbundle/8.3.x-dev/config/routes/behat/ezplatform_behat.yaml
+++ b/ezsystems/behatbundle/8.3.x-dev/config/routes/behat/ezplatform_behat.yaml
@@ -1,0 +1,2 @@
+_ezplatform_behat:
+    resource: '@eZBehatBundle/Resources/config/routing.yaml'

--- a/ezsystems/behatbundle/8.3.x-dev/manifest.json
+++ b/ezsystems/behatbundle/8.3.x-dev/manifest.json
@@ -9,5 +9,8 @@
         "behat_ibexa_content.yaml": "behat_ibexa_content.yaml",
         "behat_ibexa_experience.yaml": "behat_ibexa_experience.yaml",
         "behat_ibexa_commerce.yaml": "behat_ibexa_commerce.yaml"
+    },
+    "copy-from-recipe": {
+        "config/": "%CONFIG_DIR%/"
     }
 }


### PR DESCRIPTION
Imported BehatBundle routing, they were prevoiusly present here:
https://github.com/ezsystems/ezplatform/blob/master/config/routes/behat/ezplatform_behat.yaml

and are required for the tests in https://github.com/ezsystems/ezplatform-kernel/pull/173

I've verified locally by setting up the server with this PR, the result:
```
MacBook-Pro:v3 mareknocon$ composer recipes:install ezsystems/behatbundle --force -v
Using "http://127.0.0.1:8000" as the Symfony endpoint
Warning: Accessing 127.0.0.1 over http which is an insecure protocol.

Symfony operations: 1 recipe (5cc07e3716e4ddc01e142e9c1de83aee)
  - Configuring ezsystems/behatbundle (>=8.3.x-dev): From private:master
    Enabling the package as a Symfony bundle
    Copying files from recipe
      Created "./config/routes/behat/ezplatform_behat.yaml"
    Copying files from package
      Created "./behat_ibexa_oss.yaml"
      Created "./behat_ibexa_content.yaml"
      Created "./behat_ibexa_experience.yaml"
      Created "./behat_ibexa_commerce.yaml"
```

and I've verified that the required routes are working in `behat` env.