### PR TITLE
IBX-75: Enabled Commerce in Ibexa Commerce edition

### DIFF
--- a/ibexa/commerce/3.3.x-dev/config/packages/ecommerce.yaml
+++ b/ibexa/commerce/3.3.x-dev/config/packages/ecommerce.yaml
@@ -6,3 +6,9 @@ imports:
     - { resource: ezcommerce/ezcommerce_demo.yaml }
     - { resource: ezcommerce/ezcommerce_common.yaml }
     - { resource: ezcommerce/ezcommerce_advanced.yaml }
+
+ezplatform:
+    system:
+        default:
+            commerce:
+                enabled: true


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-75](https://issues.ibexa.co/browse/IBX-75)
| **Required by**                          | <ul><li>ezsystems/ezcommerce-shop#278</li><li>ibexa/installer#22</li></ul>
| **Type**                                   | feature
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | yes

Since ezsystems/ezcommerce-shop#278 disables Commerce by default for sanity reasons[1], the new recipe for Commerce 3.3.2+ needs to enable it.

[1] [IBX-75](https://issues.ibexa.co/browse/IBX-75) requirement was to make Commerce installation optional for Content & Experience and 3.2 upgrade to Experience 3.3.