### PR TITLE
Added missing ezrecommendation-client routes

### DIFF
--- a/ibexa/commerce/3.3.x-dev/config/routes/ezrecommendation_client.yaml
+++ b/ibexa/commerce/3.3.x-dev/config/routes/ezrecommendation_client.yaml
@@ -1,0 +1,3 @@
+ezrecommendation_client:
+    resource: "@EzRecommendationClientBundle/Resources/config/routing_rest.yaml"
+    prefix:   '%ezpublish_rest.path_prefix%'

--- a/ibexa/content/3.3.x-dev/config/routes/ezrecommendation_client.yaml
+++ b/ibexa/content/3.3.x-dev/config/routes/ezrecommendation_client.yaml
@@ -1,0 +1,3 @@
+ezrecommendation_client:
+    resource: "@EzRecommendationClientBundle/Resources/config/routing_rest.yaml"
+    prefix:   '%ezpublish_rest.path_prefix%'

--- a/ibexa/experience/3.3.x-dev/config/routes/ezrecommendation_client.yaml
+++ b/ibexa/experience/3.3.x-dev/config/routes/ezrecommendation_client.yaml
@@ -1,0 +1,3 @@
+ezrecommendation_client:
+    resource: "@EzRecommendationClientBundle/Resources/config/routing_rest.yaml"
+    prefix:   '%ezpublish_rest.path_prefix%'


### PR DESCRIPTION
This PR provides added missing ezrecommendation-client routes. Routes are required by recommendation engine for fetching content.