### PR TITLE
IBX-371: Removed Kaliop from 3.3.x and 4.0.x versions

### DIFF
--- a/ibexa/commerce/3.3.x-dev/manifest.json
+++ b/ibexa/commerce/3.3.x-dev/manifest.json
@@ -69,7 +69,6 @@
     "Siso\\Bundle\\EzStudioBundle\\SisoEzStudioBundle": ["all"],
     "Siso\\Bundle\\ComparisonBundle\\SisoComparisonBundle": ["all"],
     "Siso\\Bundle\\PaymentBundle\\SisoPaymentBundle": ["all"],
-    "Kaliop\\eZMigrationBundle\\eZMigrationBundle": ["all"],
     "Siso\\Bundle\\PriceBundle\\SisoPriceBundle": ["all"],
     "Siso\\Bundle\\QuickOrderBundle\\SisoQuickOrderBundle": ["all"],
     "Siso\\Bundle\\ToolsBundle\\SisoToolsBundle": ["all"],

--- a/ibexa/commerce/4.0.x-dev/manifest.json
+++ b/ibexa/commerce/4.0.x-dev/manifest.json
@@ -69,7 +69,6 @@
     "Siso\\Bundle\\EzStudioBundle\\SisoEzStudioBundle": ["all"],
     "Siso\\Bundle\\ComparisonBundle\\SisoComparisonBundle": ["all"],
     "Siso\\Bundle\\PaymentBundle\\SisoPaymentBundle": ["all"],
-    "Kaliop\\eZMigrationBundle\\eZMigrationBundle": ["all"],
     "Siso\\Bundle\\PriceBundle\\SisoPriceBundle": ["all"],
     "Siso\\Bundle\\QuickOrderBundle\\SisoQuickOrderBundle": ["all"],
     "Siso\\Bundle\\ToolsBundle\\SisoToolsBundle": ["all"],

--- a/ibexa/content/3.3.x-dev/manifest.json
+++ b/ibexa/content/3.3.x-dev/manifest.json
@@ -68,7 +68,6 @@
     "Nelmio\\SolariumBundle\\NelmioSolariumBundle": ["all"],
     "JMS\\Payment\\CoreBundle\\JMSPaymentCoreBundle": ["all"],
     "Joli\\ApacheTikaBundle\\ApacheTikaBundle": ["all"],
-    "Kaliop\\eZMigrationBundle\\eZMigrationBundle": ["all"],
     "JMS\\JobQueueBundle\\JMSJobQueueBundle": ["all"],
     "FOS\\RestBundle\\FOSRestBundle": ["all"],
     "JMS\\SerializerBundle\\JMSSerializerBundle": ["all"],

--- a/ibexa/content/4.0.x-dev/manifest.json
+++ b/ibexa/content/4.0.x-dev/manifest.json
@@ -68,7 +68,6 @@
     "Nelmio\\SolariumBundle\\NelmioSolariumBundle": ["all"],
     "JMS\\Payment\\CoreBundle\\JMSPaymentCoreBundle": ["all"],
     "Joli\\ApacheTikaBundle\\ApacheTikaBundle": ["all"],
-    "Kaliop\\eZMigrationBundle\\eZMigrationBundle": ["all"],
     "JMS\\JobQueueBundle\\JMSJobQueueBundle": ["all"],
     "FOS\\RestBundle\\FOSRestBundle": ["all"],
     "JMS\\SerializerBundle\\JMSSerializerBundle": ["all"],

--- a/ibexa/experience/3.3.x-dev/manifest.json
+++ b/ibexa/experience/3.3.x-dev/manifest.json
@@ -75,7 +75,6 @@
     "Nelmio\\SolariumBundle\\NelmioSolariumBundle": ["all"],
     "JMS\\Payment\\CoreBundle\\JMSPaymentCoreBundle": ["all"],
     "Joli\\ApacheTikaBundle\\ApacheTikaBundle": ["all"],
-    "Kaliop\\eZMigrationBundle\\eZMigrationBundle": ["all"],
     "JMS\\JobQueueBundle\\JMSJobQueueBundle": ["all"],
     "FOS\\RestBundle\\FOSRestBundle": ["all"],
     "JMS\\SerializerBundle\\JMSSerializerBundle": ["all"],

--- a/ibexa/experience/4.0.x-dev/manifest.json
+++ b/ibexa/experience/4.0.x-dev/manifest.json
@@ -75,7 +75,6 @@
     "Nelmio\\SolariumBundle\\NelmioSolariumBundle": ["all"],
     "JMS\\Payment\\CoreBundle\\JMSPaymentCoreBundle": ["all"],
     "Joli\\ApacheTikaBundle\\ApacheTikaBundle": ["all"],
-    "Kaliop\\eZMigrationBundle\\eZMigrationBundle": ["all"],
     "JMS\\JobQueueBundle\\JMSJobQueueBundle": ["all"],
     "FOS\\RestBundle\\FOSRestBundle": ["all"],
     "JMS\\SerializerBundle\\JMSSerializerBundle": ["all"],


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-371](https://issues.ibexa.co/browse/IBX-371)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3.3`

Fixes failing build in Travis.

Kaliop should not be included by default in 3.3.3 and 4.0 installations.