### PR TITLE
IBX-768: Removed REST prefix from order management routes

### DIFF
--- a/ibexa/commerce/3.3.x-dev/config/routes/ezcommerce.yaml
+++ b/ibexa/commerce/3.3.x-dev/config/routes/ezcommerce.yaml
@@ -40,7 +40,7 @@ siso_orderhistory:
 
 siso_local_order_management:
     resource: '@SisoLocalOrderManagementBundle/Resources/config/routing.yml'
-    prefix: '%ezpublish_rest.path_prefix%'
+    prefix: /
 
 silver_eshop_admin_rest_api:
     resource: '@IbexaPlatformCommerceAdminUiBundle/Resources/config/routing_rest.yml'

--- a/ibexa/commerce/4.0.x-dev/config/routes/ezcommerce.yaml
+++ b/ibexa/commerce/4.0.x-dev/config/routes/ezcommerce.yaml
@@ -40,7 +40,7 @@ siso_orderhistory:
 
 siso_local_order_management:
     resource: '@SisoLocalOrderManagementBundle/Resources/config/routing.yml'
-    prefix: '%ezpublish_rest.path_prefix%'
+    prefix: /
 
 silver_eshop_admin_rest_api:
     resource: '@IbexaPlatformCommerceAdminUiBundle/Resources/config/routing_rest.yml'


### PR DESCRIPTION
JIRA issue: https://issues.ibexa.co/browse/IBX-768

The routes for `SisoLocalOrderManagementBundle` are imported with `'%ezpublish_rest.path_prefix%'` prefix which results in some links being treated like rest calls, and for example, when using `Map\Host` matcher with Order Management submitting the form makes `EzSystems\EzPlatformRestBundle\EventListener\CsrfListener` complains about missing `X-CSRF-Token` and throws 401.