### PR TITLE
[ezsystems/behatbundle] Added default monolog configuration

### DIFF
--- a/ezsystems/behatbundle/8.3.x-dev/config/packages/behat/monolog.yaml
+++ b/ezsystems/behatbundle/8.3.x-dev/config/packages/behat/monolog.yaml
@@ -1,0 +1,5 @@
+monolog:
+    handlers:
+        travis:
+            type: stream
+            level: error

--- a/ezsystems/behatbundle/9.0.x-dev/config/packages/behat/monolog.yaml
+++ b/ezsystems/behatbundle/9.0.x-dev/config/packages/behat/monolog.yaml
@@ -1,0 +1,5 @@
+monolog:
+    handlers:
+        travis:
+            type: stream
+            level: error


### PR DESCRIPTION
JIRA: https://issues.ibexa.co/browse/IBX-839

Adding the monolog configuration previously found in metarepo:
https://github.com/ezsystems/ezplatform/blob/3.2/config/packages/behat/monolog.yaml

We don't need the special log file name, `behat.log` is fine as well.

Tested locally:
- v3.3
```
Symfony operations: 1 recipe (480f8a1e799616c557cbd621d74eb2aa)
  - Configuring ezsystems/behatbundle (>=8.3.x-dev): From private:master
    Enabling the package as a Symfony bundle
    Copying files from recipe
      Created "./config/packages/behat/monolog.yaml"
      Created "./config/routes/behat/ezplatform_behat.yaml"
    Copying files from package
      Created "./behat_ibexa_oss.yaml"
      Created "./behat_ibexa_content.yaml"
      Created "./behat_ibexa_experience.yaml"
      Created "./behat_ibexa_commerce.yaml"
```
- v4.0
```
  - Configuring ezsystems/behatbundle (>=9.0.x-dev): From private:master
    Enabling the package as a Symfony bundle
    Copying files from recipe
      Created "./config/packages/behat/monolog.yaml"
      Created "./config/routes/behat/ezplatform_behat.yaml"
    Copying files from package
      Created "./behat_ibexa_oss.yaml"
      Created "./behat_ibexa_content.yaml"
      Created "./behat_ibexa_experience.yaml"
      Created "./behat_ibexa_commerce.yaml"
```