### PR TITLE
define default env vars to avoid warnings on deploying to cloud

### DIFF
--- a/ibexa/commerce/3.3.x-dev/config/packages/ezplatform_http_cache_fastly.yaml
+++ b/ibexa/commerce/3.3.x-dev/config/packages/ezplatform_http_cache_fastly.yaml
@@ -1,4 +1,6 @@
 parameters:
+    env(FASTLY_SERVICE_ID): ~
+    env(FASTLY_KEY): ~
     fastly_service_id: '%env(FASTLY_SERVICE_ID)%'
     fastly_key: '%env(FASTLY_KEY)%'
 

--- a/ibexa/commerce/4.0.x-dev/config/packages/ezplatform_http_cache_fastly.yaml
+++ b/ibexa/commerce/4.0.x-dev/config/packages/ezplatform_http_cache_fastly.yaml
@@ -1,4 +1,6 @@
 parameters:
+    env(FASTLY_SERVICE_ID): ~
+    env(FASTLY_KEY): ~
     fastly_service_id: '%env(FASTLY_SERVICE_ID)%'
     fastly_key: '%env(FASTLY_KEY)%'
 

--- a/ibexa/content/3.3.x-dev/config/packages/ezplatform_http_cache_fastly.yaml
+++ b/ibexa/content/3.3.x-dev/config/packages/ezplatform_http_cache_fastly.yaml
@@ -1,4 +1,6 @@
 parameters:
+    env(FASTLY_SERVICE_ID): ~
+    env(FASTLY_KEY): ~
     fastly_service_id: '%env(FASTLY_SERVICE_ID)%'
     fastly_key: '%env(FASTLY_KEY)%'
 

--- a/ibexa/content/4.0.x-dev/config/packages/ezplatform_http_cache_fastly.yaml
+++ b/ibexa/content/4.0.x-dev/config/packages/ezplatform_http_cache_fastly.yaml
@@ -1,4 +1,6 @@
 parameters:
+    env(FASTLY_SERVICE_ID): ~
+    env(FASTLY_KEY): ~
     fastly_service_id: '%env(FASTLY_SERVICE_ID)%'
     fastly_key: '%env(FASTLY_KEY)%'
 

--- a/ibexa/experience/3.3.x-dev/config/packages/ezplatform_http_cache_fastly.yaml
+++ b/ibexa/experience/3.3.x-dev/config/packages/ezplatform_http_cache_fastly.yaml
@@ -1,4 +1,6 @@
 parameters:
+    env(FASTLY_SERVICE_ID): ~
+    env(FASTLY_KEY): ~
     fastly_service_id: '%env(FASTLY_SERVICE_ID)%'
     fastly_key: '%env(FASTLY_KEY)%'
 

--- a/ibexa/experience/4.0.x-dev/config/packages/ezplatform_http_cache_fastly.yaml
+++ b/ibexa/experience/4.0.x-dev/config/packages/ezplatform_http_cache_fastly.yaml
@@ -1,4 +1,6 @@
 parameters:
+    env(FASTLY_SERVICE_ID): ~
+    env(FASTLY_KEY): ~
     fastly_service_id: '%env(FASTLY_SERVICE_ID)%'
     fastly_key: '%env(FASTLY_KEY)%'
 


### PR DESCRIPTION
Whenever you deploy to Ibexa cloud you can see warnings like 
```
Redeploying environment master

  Preparing deployment

  Closing services router, app, and varnish

  Opening application app and its relationships

  Executing deploy hook for application app

    

     // Clearing the cache for the prod environment with debug                      

     // false                                                                       

    

    W: 06:21:49 WARNING   [app] Failed to generate ConfigBuilder for extension Symfony\Bundle\FrameworkBundle\DependencyInjection\FrameworkExtension. ["exception" => Symfony\Component\DependencyInjection\Exception\EnvNotFoundException { …},"extensionClass" => "Symfony\Bundle\FrameworkBundle\DependencyInjection\FrameworkExtension"]

    W: 06:21:50 WARNING   [app] Failed to generate ConfigBuilder for extension Sensio\Bundle\FrameworkExtraBundle\DependencyInjection\SensioFrameworkExtraExtension. ["exception" => Symfony\Component\DependencyInjection\Exception\EnvNotFoundException { …},"extensionClass" => "Sensio\Bundle\FrameworkExtraBundle\DependencyInjection\SensioFrameworkExtraExtension"]

    W: 06:21:50 WARNING   [app] Failed to generate ConfigBuilder for extension Symfony\Bundle\TwigBundle\DependencyInjection\TwigExtension. ["exception" => Symfony\Component\DependencyInjection\Exception\EnvNotFoundException { …},"extensionClass" => "Symfony\Bundle\TwigBundle\DependencyInjection\TwigExtension"]

    W: 06:21:50 WARNING   [app] Failed to generate ConfigBuilder for extension Symfony\Bundle\MonologBundle\DependencyInjection\MonologExtension. ["exception" => Symfony\Component\DependencyInjection\Exception\EnvNotFoundException { …},"extensionClass" => "Symfony\Bundle\MonologBundle\DependencyInjection\MonologExtension"]

    W: 06:21:50 WARNING   [app] Failed to generate ConfigBuilder for extension Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension. ["exception" => Symfony\Component\DependencyInjection\Exception\EnvNotFoundException { …},"extensionClass" => "Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension"]

    W: 06:21:50 WARNING   [app] Failed to generate ConfigBuilder for extension Doctrine\Bundle\MigrationsBundle\DependencyInjection\DoctrineMigrationsExtension. ["exception" => Symfony\Component\DependencyInjection\Exception\EnvNotFoundException { …},"extensionClass" => "Doctrine\Bundle\MigrationsBundle\DependencyInjection\DoctrineMigrationsExtension"]

    W: 06:21:50 WARNING   [app] Failed to generate ConfigBuilder for extension Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension. ["exception" => Symfony\Component\DependencyInjection\Exception\EnvNotFoundException { …},"extensionClass" => "Symfony\Bundle\SecurityBundle\DependencyInjection\SecurityExtension"]

    W: 06:21:50 WARNING   [app] Failed to generate ConfigBuilder for extension Twig\Extra\TwigExtraBundle\DependencyInjection\TwigExtraExtension. ["exception" => Symfony\Component\DependencyInjection\Exception\EnvNotFoundException { …},"extensionClass" => "Twig\Extra\TwigExtraBundle\DependencyInjection\TwigExtraExtension"]

    W:
....
```

As part of this https://issues.ibexa.co/browse/IBX-301 I've been debugging and found that the warning appears because these two env vars have no default values. when we remove the files inside `var/cache/prod/*.*` and do a `php bin/console c:c` those warnings appears. Also you can reproduce this locally. 

I think It won't hurt to define this env vars to avoid this kind of warnings. While this does not fix the cache clearing issue that we are noticing, it still avoids the appear of all those warnings. 

Let  me now if I did this correct. 