### PR TITLE
Fixed default email adresses for commerce

### DIFF
--- a/ibexa/commerce/3.3.x-dev/config/packages/ezcommerce/ecommerce_parameters.yaml
+++ b/ibexa/commerce/3.3.x-dev/config/packages/ezcommerce/ecommerce_parameters.yaml
@@ -1,15 +1,15 @@
 parameters:
     siso_core.default.ses_swiftmailer:
-        mailSender: shop@silversolutions.de
-        mailReceiver: shop@silversolutions.de
-        lostOrderEmailReceiver: shop@silversolutions.de
-        contactMailReceiver: shop@silversolutions.de
-        cancellationMailReceiver: shop@silversolutions.de
-        shopOwnerMailReceiver: shop@silversolutions.de
-    ses_eshop.forms.business.default_contact_recipient: shop@silversolutions.de
-    ses_eshop.order.sales_contact: shop@silversolutions.de
-    ses_eshop.lostorder_email: shop@silversolutions.de
-    siso_paypal_payment.receiver_email: shop@silver.de
+        mailSender: noreply@ibexa.co
+        mailReceiver: noreply@ibexa.co
+        lostOrderEmailReceiver: noreply@ibexa.co
+        contactMailReceiver: noreply@ibexa.co
+        cancellationMailReceiver: noreply@ibexa.co
+        shopOwnerMailReceiver: noreply@ibexa.co
+    ses_eshop.forms.business.default_contact_recipient: noreply@ibexa.co
+    ses_eshop.order.sales_contact: noreply@ibexa.co
+    ses_eshop.lostorder_email: noreply@ibexa.co
+    siso_paypal_payment.receiver_email: noreply@ibexa.co
 
     siso_core.siteaccess_group: ezdemo_site_clean_group
     apache_tika_path: '%kernel.project_dir%/bin/tika-app-1.20.jar'

--- a/ibexa/commerce/4.0.x-dev/config/packages/ezcommerce/ecommerce_parameters.yaml
+++ b/ibexa/commerce/4.0.x-dev/config/packages/ezcommerce/ecommerce_parameters.yaml
@@ -1,15 +1,15 @@
 parameters:
     siso_core.default.ses_swiftmailer:
-        mailSender: shop@silversolutions.de
-        mailReceiver: shop@silversolutions.de
-        lostOrderEmailReceiver: shop@silversolutions.de
-        contactMailReceiver: shop@silversolutions.de
-        cancellationMailReceiver: shop@silversolutions.de
-        shopOwnerMailReceiver: shop@silversolutions.de
-    ses_eshop.forms.business.default_contact_recipient: shop@silversolutions.de
-    ses_eshop.order.sales_contact: shop@silversolutions.de
-    ses_eshop.lostorder_email: shop@silversolutions.de
-    siso_paypal_payment.receiver_email: shop@silver.de
+        mailSender: noreply@ibexa.co
+        mailReceiver: noreply@ibexa.co
+        lostOrderEmailReceiver: noreply@ibexa.co
+        contactMailReceiver: noreply@ibexa.co
+        cancellationMailReceiver: noreply@ibexa.co
+        shopOwnerMailReceiver: noreply@ibexa.co
+    ses_eshop.forms.business.default_contact_recipient: noreply@ibexa.co
+    ses_eshop.order.sales_contact: noreply@ibexa.co
+    ses_eshop.lostorder_email: noreply@ibexa.co
+    siso_paypal_payment.receiver_email: noreply@ibexa.co
 
     siso_core.siteaccess_group: ezdemo_site_clean_group
     apache_tika_path: '%kernel.project_dir%/bin/tika-app-1.20.jar'

--- a/ibexa/content/3.3.x-dev/config/packages/ezcommerce/ecommerce_parameters.yaml
+++ b/ibexa/content/3.3.x-dev/config/packages/ezcommerce/ecommerce_parameters.yaml
@@ -1,15 +1,15 @@
 parameters:
     siso_core.default.ses_swiftmailer:
-        mailSender: shop@silversolutions.de
-        mailReceiver: shop@silversolutions.de
-        lostOrderEmailReceiver: shop@silversolutions.de
-        contactMailReceiver: shop@silversolutions.de
-        cancellationMailReceiver: shop@silversolutions.de
-        shopOwnerMailReceiver: shop@silversolutions.de
-    ses_eshop.forms.business.default_contact_recipient: shop@silversolutions.de
-    ses_eshop.order.sales_contact: shop@silversolutions.de
-    ses_eshop.lostorder_email: shop@silversolutions.de
-    siso_paypal_payment.receiver_email: shop@silver.de
+        mailSender: noreply@ibexa.co
+        mailReceiver: noreply@ibexa.co
+        lostOrderEmailReceiver: noreply@ibexa.co
+        contactMailReceiver: noreply@ibexa.co
+        cancellationMailReceiver: noreply@ibexa.co
+        shopOwnerMailReceiver: noreply@ibexa.co
+    ses_eshop.forms.business.default_contact_recipient: noreply@ibexa.co
+    ses_eshop.order.sales_contact: noreply@ibexa.co
+    ses_eshop.lostorder_email: noreply@ibexa.co
+    siso_paypal_payment.receiver_email: noreply@ibexa.co
 
     siso_core.siteaccess_group: ezdemo_site_clean_group
     apache_tika_path: '%kernel.project_dir%/bin/tika-app-1.20.jar'

--- a/ibexa/content/4.0.x-dev/config/packages/ezcommerce/ecommerce_parameters.yaml
+++ b/ibexa/content/4.0.x-dev/config/packages/ezcommerce/ecommerce_parameters.yaml
@@ -1,15 +1,15 @@
 parameters:
     siso_core.default.ses_swiftmailer:
-        mailSender: shop@silversolutions.de
-        mailReceiver: shop@silversolutions.de
-        lostOrderEmailReceiver: shop@silversolutions.de
-        contactMailReceiver: shop@silversolutions.de
-        cancellationMailReceiver: shop@silversolutions.de
-        shopOwnerMailReceiver: shop@silversolutions.de
-    ses_eshop.forms.business.default_contact_recipient: shop@silversolutions.de
-    ses_eshop.order.sales_contact: shop@silversolutions.de
-    ses_eshop.lostorder_email: shop@silversolutions.de
-    siso_paypal_payment.receiver_email: shop@silver.de
+        mailSender: noreply@ibexa.co
+        mailReceiver: noreply@ibexa.co
+        lostOrderEmailReceiver: noreply@ibexa.co
+        contactMailReceiver: noreply@ibexa.co
+        cancellationMailReceiver: noreply@ibexa.co
+        shopOwnerMailReceiver: noreply@ibexa.co
+    ses_eshop.forms.business.default_contact_recipient: noreply@ibexa.co
+    ses_eshop.order.sales_contact: noreply@ibexa.co
+    ses_eshop.lostorder_email: noreply@ibexa.co
+    siso_paypal_payment.receiver_email: noreply@ibexa.co
 
     siso_core.siteaccess_group: ezdemo_site_clean_group
     apache_tika_path: '%kernel.project_dir%/bin/tika-app-1.20.jar'

--- a/ibexa/experience/3.3.x-dev/config/packages/ezcommerce/ecommerce_parameters.yaml
+++ b/ibexa/experience/3.3.x-dev/config/packages/ezcommerce/ecommerce_parameters.yaml
@@ -1,15 +1,15 @@
 parameters:
     siso_core.default.ses_swiftmailer:
-        mailSender: shop@silversolutions.de
-        mailReceiver: shop@silversolutions.de
-        lostOrderEmailReceiver: shop@silversolutions.de
-        contactMailReceiver: shop@silversolutions.de
-        cancellationMailReceiver: shop@silversolutions.de
-        shopOwnerMailReceiver: shop@silversolutions.de
-    ses_eshop.forms.business.default_contact_recipient: shop@silversolutions.de
-    ses_eshop.order.sales_contact: shop@silversolutions.de
-    ses_eshop.lostorder_email: shop@silversolutions.de
-    siso_paypal_payment.receiver_email: shop@silver.de
+        mailSender: noreply@ibexa.co
+        mailReceiver: noreply@ibexa.co
+        lostOrderEmailReceiver: noreply@ibexa.co
+        contactMailReceiver: noreply@ibexa.co
+        cancellationMailReceiver: noreply@ibexa.co
+        shopOwnerMailReceiver: noreply@ibexa.co
+    ses_eshop.forms.business.default_contact_recipient: noreply@ibexa.co
+    ses_eshop.order.sales_contact: noreply@ibexa.co
+    ses_eshop.lostorder_email: noreply@ibexa.co
+    siso_paypal_payment.receiver_email: noreply@ibexa.co
 
     siso_core.siteaccess_group: ezdemo_site_clean_group
     apache_tika_path: '%kernel.project_dir%/bin/tika-app-1.20.jar'

--- a/ibexa/experience/4.0.x-dev/config/packages/ezcommerce/ecommerce_parameters.yaml
+++ b/ibexa/experience/4.0.x-dev/config/packages/ezcommerce/ecommerce_parameters.yaml
@@ -1,15 +1,15 @@
 parameters:
     siso_core.default.ses_swiftmailer:
-        mailSender: shop@silversolutions.de
-        mailReceiver: shop@silversolutions.de
-        lostOrderEmailReceiver: shop@silversolutions.de
-        contactMailReceiver: shop@silversolutions.de
-        cancellationMailReceiver: shop@silversolutions.de
-        shopOwnerMailReceiver: shop@silversolutions.de
-    ses_eshop.forms.business.default_contact_recipient: shop@silversolutions.de
-    ses_eshop.order.sales_contact: shop@silversolutions.de
-    ses_eshop.lostorder_email: shop@silversolutions.de
-    siso_paypal_payment.receiver_email: shop@silver.de
+        mailSender: noreply@ibexa.co
+        mailReceiver: noreply@ibexa.co
+        lostOrderEmailReceiver: noreply@ibexa.co
+        contactMailReceiver: noreply@ibexa.co
+        cancellationMailReceiver: noreply@ibexa.co
+        shopOwnerMailReceiver: noreply@ibexa.co
+    ses_eshop.forms.business.default_contact_recipient: noreply@ibexa.co
+    ses_eshop.order.sales_contact: noreply@ibexa.co
+    ses_eshop.lostorder_email: noreply@ibexa.co
+    siso_paypal_payment.receiver_email: noreply@ibexa.co
 
     siso_core.siteaccess_group: ezdemo_site_clean_group
     apache_tika_path: '%kernel.project_dir%/bin/tika-app-1.20.jar'


### PR DESCRIPTION
PR sets all commerce related email adresses to _noreply@ibexa.co_
(same as in \ezsystems\ezcommerce-shop\src\Silversolutions\Bundle\EshopBundle\Resources\config\emails.yml )