### PR TITLE
[Fast forward][Rebranding] Fixed missing App namespace in src/Kernel for 4.0.x-dev

### DIFF
--- a/ibexa/commerce/4.0.x-dev/src/Kernel.php
+++ b/ibexa/commerce/4.0.x-dev/src/Kernel.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+namespace App;
+
 use Ibexa\Bundle\CompatibilityLayer\Kernel\BundleCompatibilityTrait;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;

--- a/ibexa/content/4.0.x-dev/src/Kernel.php
+++ b/ibexa/content/4.0.x-dev/src/Kernel.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+namespace App;
+
 use Ibexa\Bundle\CompatibilityLayer\Kernel\BundleCompatibilityTrait;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;

--- a/ibexa/experience/4.0.x-dev/src/Kernel.php
+++ b/ibexa/experience/4.0.x-dev/src/Kernel.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+namespace App;
+
 use Ibexa\Bundle\CompatibilityLayer\Kernel\BundleCompatibilityTrait;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;

--- a/ibexa/oss/4.0.x-dev/src/Kernel.php
+++ b/ibexa/oss/4.0.x-dev/src/Kernel.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+namespace App;
+
 use Ibexa\Bundle\CompatibilityLayer\Kernel\BundleCompatibilityTrait;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | Related to changes for [IBX-88](https://issues.ibexa.co/browse/IBX-88)
| **Type**                                   | bug
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | no

Follow up to newly added src/Kernel for 4.0.x-dev with our Compatibility Layer trait