### PR TITLE
[ibexa/docker] Added recipes for 0.2 version series

### DIFF
--- a/ibexa/docker/0.2.x-dev/manifest.json
+++ b/ibexa/docker/0.2.x-dev/manifest.json
@@ -1,0 +1,41 @@
+{
+    "aliases": [],
+      "copy-from-package": {
+        "scripts/vhost.sh": "bin/vhost.sh",
+        "docker/": "doc/docker/",
+        "templates/apache2/": "doc/apache2/",
+        "templates/nginx/": "doc/nginx/"
+      },
+      "env": {
+        "#0": "Composer configuration on local:",
+        "COMPOSER_HOME": "~/.composer",
+        "#1": "# Docker Compose configuration",
+        "COMPOSE_FILE": "doc/docker/base-dev.yml",
+        "COMPOSE_DIR": ".",
+        "COMPOSE_PROJECT_NAME": "ibexa",
+        "PHP_IMAGE": "ezsystems/php:7.3-v2-node12",
+        "NGINX_IMAGE": "nginx:stable",
+        "MYSQL_IMAGE": "healthcheck/mariadb",
+        "REDIS_IMAGE": "healthcheck/redis",
+        "#2": "# Behat / Selenium config",
+        "#3": "## web host refer to the tip of the setup, so varnish if that is used.",
+        "SELENIUM_IMAGE": "selenium/standalone-chrome-debug:3.141.59-20210422",
+        "CHROMIUM_IMAGE": "registry.gitlab.com/dmore/docker-chrome-headless:7.1",
+        "WEB_HOST": "http://web",
+        "MINK_DEFAULT_SESSION": "selenium",
+        "SELENIUM_HOST": "http://selenium:4444/wd/hub",
+        "CHROMIUM_HOST": "http://chromium:9222",
+        "#4": "Database configuration for Docker",
+        "DATABASE_USER": "ezp",
+        "DATABASE_PASSWORD": "SetYourOwnPassword",
+        "DATABASE_NAME": "ezp",
+        "DATABASE_HOST": "db",
+        "DATABASE_PORT": "3306",
+        "DATABASE_PLATFORM": "mysql",
+        "DATABASE_DRIVER": "pdo_mysql",
+        "#5": "Needed by Doctrine Bundle / ORM to avoid it opening connection during situations where there is no service yet.",
+        "#6": "See: https://symfony.com/doc/current/reference/configuration/doctrine.html#doctrine-dbal-configuration",
+        "DATABASE_VERSION": "mariadb-10.3.0",
+        "DATABASE_URL": "${DATABASE_PLATFORM}://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}?serverVersion=${DATABASE_VERSION}"
+      }
+}


### PR DESCRIPTION
Adding a recipe for ibexa/docker, version 0.2.x-dev. It's the same file as for 0.1.x-dev: https://github.com/ibexa/recipes/blob/master/ibexa/docker/0.1.x-dev/manifest.json

We need to add this because browser tests for v4 are using incorrect Selenium version.

Example build for v3.3 (https://github.com/ezsystems/ezplatform-admin-ui/runs/4431815048?check_suite_focus=true):
```
Running composer update ibexa/docker
Loading composer repositories with package information
Warning from https://flex.ibexa.co/versions.json: You are using an outdated version of Flex, please run: composer update symfony/flex
Updating dependencies
Lock file operations: 1 install, 0 updates, 0 removals
  - Locking ibexa/docker (0.1.x-dev 59a1f42)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 1 install, 0 updates, 0 removals
  - Downloading ibexa/docker (0.1.x-dev 59a1f42)
  - Installing ibexa/docker (0.1.x-dev 59a1f42): Extracting archive
 (...)
 Symfony operations: 1 recipe (a45dda813691109ea7bc65de9d5295ab)
  - Configuring ibexa/docker (>=0.1.x-dev): From private:master
Run command with -v to see more details
```

You can see that 0.1.x-dev is used for recipes.

Example build for v4 (https://github.com/ibexa/admin-ui/runs/4429343865?check_suite_focus=true)
```
 Running composer update ibexa/docker
Loading composer repositories with package information
Warning from https://flex.ibexa.co/versions.json: You are using an outdated version of Flex, please run: composer update symfony/flex
Updating dependencies
Lock file operations: 1 install, 0 updates, 0 removals
  - Locking ibexa/docker (dev-main 2f73c06)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 1 install, 0 updates, 0 removals
  - Downloading ibexa/docker (dev-main 2f73c06)
  - Installing ibexa/docker (dev-main 2f73c06): Extracting archive
Package swiftmailer/swiftmailer is abandoned, you should avoid using it. Use symfony/mailer instead.
Package fzaninotto/faker is abandoned, you should avoid using it. No replacement was suggested.
Generating optimized autoload files
composer/package-versions-deprecated: Generating version class...
composer/package-versions-deprecated: ...done generating version class
134 packages you are using are looking for funding.
Use the `composer fund` command to find out more!

Symfony operations: 1 recipe (fab822631f7d604e28936ce47b78df1f)
  - Configuring ibexa/docker (>=0.1): From private:master
Run command with -v to see more details
```

This time 0.1 is used.

It matters because these recipes differ when it comes to Selenium image version:
- https://github.com/ibexa/recipes/blob/master/ibexa/docker/0.1.x-dev/manifest.json#L22 : `3.141.59-20210422`
- https://github.com/ibexa/recipes/blob/master/ibexa/docker/0.1/manifest.json#L22 : `3.141.59-20200326`

And you can see in the logs that incorrect image is used:
v3.3: `Pulling selenium (selenium/standalone-chrome-debug:3.141.59-20210422)...`
v4.0: `Pulling selenium (selenium/standalone-chrome-debug:3.141.59-20200326)...`

Adding the 0.2.x-dev version to recipes (it's the same as 0.1.x-dev) results in correct recipes taken into account:
```
~/Desktop/Sites/v3_4 on master ❯ composer require --dev ibexa/docker:^0.2.x-dev --no-scripts                                                                                                                                    at 17:25:09
./composer.json has been updated
Running composer update ibexa/docker
Loading composer repositories with package information
Warning: Accessing 127.0.0.1 over http which is an insecure protocol.
Warning from http://127.0.0.1:8000/versions.json: You are using an outdated version of Flex, please run: composer update symfony/flex
Updating dependencies
Lock file operations: 1 install, 0 updates, 0 removals
  - Locking ibexa/docker (dev-main 2f73c06)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 1 install, 0 updates, 0 removals
  - Downloading ibexa/docker (dev-main 2f73c06)
  - Installing ibexa/docker (dev-main 2f73c06): Extracting archive
(...)
Symfony operations: 1 recipe (90412d1d4f8661d85af9e41e258d6929)
  - Configuring ibexa/docker (>=0.2.x-dev): From private:master
  - ```