### PR TITLE
[Fast Forward] IBX-1589: Aligned configuration with the new extension names

### DIFF
--- a/ibexa/commerce/4.0.x-dev/config/packages/dfs/dfs.yaml
+++ b/ibexa/commerce/4.0.x-dev/config/packages/dfs/dfs.yaml
@@ -29,7 +29,7 @@ oneup_flysystem:
                 service: ibexa.platform.io.nfs.adapter.site_access_aware
 
 # define the ez handlers
-ez_io:
+ibexa_io:
     binarydata_handlers:
         nfs:
             flysystem:

--- a/ibexa/commerce/4.0.x-dev/config/packages/ibexa_doctrine_schema.yaml
+++ b/ibexa/commerce/4.0.x-dev/config/packages/ibexa_doctrine_schema.yaml
@@ -4,7 +4,7 @@ parameters:
     database_collation: '%env(DATABASE_COLLATION)%'
 
 # If you are not using MySQL, you can comment-out this section
-ez_doctrine_schema:
+ibexa_doctrine_schema:
     tables:
         options:
             charset: '%database_charset%'

--- a/ibexa/commerce/4.0.x-dev/config/packages/ibexa_elasticsearch.yaml
+++ b/ibexa/commerce/4.0.x-dev/config/packages/ibexa_elasticsearch.yaml
@@ -2,7 +2,7 @@
 parameters:
     elasticsearch_dsn: "%env(ELASTICSEARCH_DSN)%"
 
-ezplatform_elastic_search_engine:
+ibexa_elasticsearch:
     connections:
         default:
             hosts:

--- a/ibexa/commerce/4.0.x-dev/config/packages/ibexa_solr.yaml
+++ b/ibexa/commerce/4.0.x-dev/config/packages/ibexa_solr.yaml
@@ -5,7 +5,7 @@ parameters:
     #solr_dsn: '%env(SOLR_DSN)%'
     #solr_core: '%env(SOLR_CORE)%'
 
-ez_search_engine_solr:
+ibexa_solr:
     endpoints:
         endpoint0:
             # suffixed explicitly for compatibility with SolariumBundle used by Commerce

--- a/ibexa/content/4.0.x-dev/config/packages/dfs/dfs.yaml
+++ b/ibexa/content/4.0.x-dev/config/packages/dfs/dfs.yaml
@@ -29,7 +29,7 @@ oneup_flysystem:
                 service: ibexa.platform.io.nfs.adapter.site_access_aware
 
 # define the ez handlers
-ez_io:
+ibexa_io:
     binarydata_handlers:
         nfs:
             flysystem:

--- a/ibexa/content/4.0.x-dev/config/packages/ibexa_doctrine_schema.yaml
+++ b/ibexa/content/4.0.x-dev/config/packages/ibexa_doctrine_schema.yaml
@@ -4,7 +4,7 @@ parameters:
     database_collation: '%env(DATABASE_COLLATION)%'
 
 # If you are not using MySQL, you can comment-out this section
-ez_doctrine_schema:
+ibexa_doctrine_schema:
     tables:
         options:
             charset: '%database_charset%'

--- a/ibexa/content/4.0.x-dev/config/packages/ibexa_elasticsearch.yaml
+++ b/ibexa/content/4.0.x-dev/config/packages/ibexa_elasticsearch.yaml
@@ -2,7 +2,7 @@
 parameters:
     elasticsearch_dsn: "%env(ELASTICSEARCH_DSN)%"
 
-ezplatform_elastic_search_engine:
+ibexa_elasticsearch:
     connections:
         default:
             hosts:

--- a/ibexa/content/4.0.x-dev/config/packages/ibexa_solr.yaml
+++ b/ibexa/content/4.0.x-dev/config/packages/ibexa_solr.yaml
@@ -5,7 +5,7 @@ parameters:
     solr_dsn: '%env(SOLR_DSN)%'
     solr_core: '%env(SOLR_CORE)%'
 
-ez_search_engine_solr:
+ibexa_solr:
     endpoints:
         endpoint0:
             dsn: '%solr_dsn%'

--- a/ibexa/experience/4.0.x-dev/config/packages/dfs/dfs.yaml
+++ b/ibexa/experience/4.0.x-dev/config/packages/dfs/dfs.yaml
@@ -29,7 +29,7 @@ oneup_flysystem:
                 service: ibexa.platform.io.nfs.adapter.site_access_aware
 
 # define the ez handlers
-ez_io:
+ibexa_io:
     binarydata_handlers:
         nfs:
             flysystem:

--- a/ibexa/experience/4.0.x-dev/config/packages/ibexa_doctrine_schema.yaml
+++ b/ibexa/experience/4.0.x-dev/config/packages/ibexa_doctrine_schema.yaml
@@ -4,7 +4,7 @@ parameters:
     database_collation: '%env(DATABASE_COLLATION)%'
 
 # If you are not using MySQL, you can comment-out this section
-ez_doctrine_schema:
+ibexa_doctrine_schema:
     tables:
         options:
             charset: '%database_charset%'

--- a/ibexa/experience/4.0.x-dev/config/packages/ibexa_elasticsearch.yaml
+++ b/ibexa/experience/4.0.x-dev/config/packages/ibexa_elasticsearch.yaml
@@ -2,7 +2,7 @@
 parameters:
     elasticsearch_dsn: "%env(ELASTICSEARCH_DSN)%"
 
-ezplatform_elastic_search_engine:
+ibexa_elasticsearch:
     connections:
         default:
             hosts:

--- a/ibexa/experience/4.0.x-dev/config/packages/ibexa_solr.yaml
+++ b/ibexa/experience/4.0.x-dev/config/packages/ibexa_solr.yaml
@@ -5,7 +5,7 @@ parameters:
     solr_dsn: '%env(SOLR_DSN)%'
     solr_core: '%env(SOLR_CORE)%'
 
-ez_search_engine_solr:
+ibexa_solr:
     endpoints:
         endpoint0:
             dsn: '%solr_dsn%'

--- a/ibexa/oss/4.0.x-dev/config/packages/dfs/dfs.yaml
+++ b/ibexa/oss/4.0.x-dev/config/packages/dfs/dfs.yaml
@@ -29,7 +29,7 @@ oneup_flysystem:
                 service: ibexa.platform.io.nfs.adapter.site_access_aware
 
 # define the ez handlers
-ez_io:
+ibexa_io:
     binarydata_handlers:
         nfs:
             flysystem:

--- a/ibexa/oss/4.0.x-dev/config/packages/ibexa_doctrine_schema.yaml
+++ b/ibexa/oss/4.0.x-dev/config/packages/ibexa_doctrine_schema.yaml
@@ -4,7 +4,7 @@ parameters:
     database_collation: '%env(DATABASE_COLLATION)%'
 
 # If you are not using MySQL, you can comment-out this section
-ez_doctrine_schema:
+ibexa_doctrine_schema:
     tables:
         options:
             charset: '%database_charset%'

--- a/ibexa/oss/4.0.x-dev/config/packages/ibexa_solr.yaml
+++ b/ibexa/oss/4.0.x-dev/config/packages/ibexa_solr.yaml
@@ -5,7 +5,7 @@ parameters:
     solr_dsn: '%env(SOLR_DSN)%'
     solr_core: '%env(SOLR_CORE)%'
 
-ez_search_engine_solr:
+ibexa_solr:
     endpoints:
         endpoint0:
             dsn: '%solr_dsn%'


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1589](https://issues.ibexa.co/browse/IBX-1589)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | yes

Updated configuration root level keys after the changes [IBX-1589](https://issues.ibexa.co/browse/IBX-1589). Old names are still supported via [`ibexa/compatibility-layer`](https://github.com/ibexa/compatibility-layer).