### PR TITLE
[Fast forward] IBX-538: Rebranded core routes import key for 4.0.x-dev

### DIFF
--- a/ibexa/commerce/4.0.x-dev/config/routes/ibexa.yaml
+++ b/ibexa/commerce/4.0.x-dev/config/routes/ibexa.yaml
@@ -8,5 +8,5 @@ login_check:
 logout:
     path: /logout
 
-ezplatform_kernel_internal:
+ibexa_core_internal:
     resource: '@IbexaCoreBundle/Resources/config/routing/internal.yml'

--- a/ibexa/content/4.0.x-dev/config/routes/ibexa.yaml
+++ b/ibexa/content/4.0.x-dev/config/routes/ibexa.yaml
@@ -8,5 +8,5 @@ login_check:
 logout:
     path: /logout
 
-ezplatform_kernel_internal:
+ibexa_core_internal:
     resource: '@IbexaCoreBundle/Resources/config/routing/internal.yml'

--- a/ibexa/experience/4.0.x-dev/config/routes/ibexa.yaml
+++ b/ibexa/experience/4.0.x-dev/config/routes/ibexa.yaml
@@ -8,5 +8,5 @@ login_check:
 logout:
     path: /logout
 
-ezplatform_kernel_internal:
+ibexa_core_internal:
     resource: '@IbexaCoreBundle/Resources/config/routing/internal.yml'

--- a/ibexa/oss/4.0.x-dev/config/routes/ibexa.yaml
+++ b/ibexa/oss/4.0.x-dev/config/routes/ibexa.yaml
@@ -8,5 +8,5 @@ login_check:
 logout:
     path: /logout
 
-ezplatform_kernel_internal:
+ibexa_core_internal:
     resource: '@IbexaCoreBundle/Resources/config/routing/internal.yml'


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-538](https://issues.ibexa.co/browse/IBX-538)
| **Type**                                   | feature
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | yes

This was a leftover related to [ibexa/core](https://github.com/ibexa/core) rebranding