### PR TITLE
IBX-1489: Adjusted `solarium/solarium-bundle` deprecated `timeout` parameter

### DIFF
--- a/ibexa/commerce/3.3.x-dev/config/packages/ezcommerce/ezcommerce_advanced.yaml
+++ b/ibexa/commerce/3.3.x-dev/config/packages/ezcommerce/ezcommerce_advanced.yaml
@@ -21,30 +21,33 @@ nelmio_solarium:
             port: '%siso_search.solr.port%'
             path: '%siso_search.solr.path%'
             core: '%siso_search.solr.core%'
-            timeout: 30
         siso_core_admin:
             host: '%siso_search.solr.host%'
             port: '%siso_search.solr.port%'
             path: '%siso_search.solr.path%'
             core: admin
-            timeout: 30
         siso_econtent:
             host: '%siso_search.solr.host%'
             port: '%siso_search.solr.port%'
             path: '%siso_search.solr.path%'
             core: econtent
-            timeout: 30
         siso_econtent_back:
             host: '%siso_search.solr.host%'
             port: '%siso_search.solr.port%'
             path: '%siso_search.solr.path%'
             core: econtent_back
-            timeout: 30
 
     clients:
         default:
+            adapter_timeout: 30
             endpoints:
                 - default
+        siso_core_admin:
+            adapter_timeout: 30
+        siso_econtent:
+            adapter_timeout: 30
+        siso_econtent_back:
+            adapter_timeout: 30
         econtent:
             endpoints:
                 - siso_econtent

--- a/ibexa/commerce/3.3.x-dev/config/packages/nelmio_solarium.yaml
+++ b/ibexa/commerce/3.3.x-dev/config/packages/nelmio_solarium.yaml
@@ -5,9 +5,9 @@ nelmio_solarium:
             port: '%siso_search.solr.port%'
             path: '%siso_search.solr.path%'
             core: '%siso_search.solr.core%'
-            timeout: 30
 
     clients:
         default:
+            adapter_timeout: 30
             endpoints:
                 - default

--- a/ibexa/commerce/4.0.x-dev/config/packages/ezcommerce/ezcommerce_advanced.yaml
+++ b/ibexa/commerce/4.0.x-dev/config/packages/ezcommerce/ezcommerce_advanced.yaml
@@ -21,30 +21,33 @@ nelmio_solarium:
             port: '%siso_search.solr.port%'
             path: '%siso_search.solr.path%'
             core: '%siso_search.solr.core%'
-            timeout: 30
         siso_core_admin:
             host: '%siso_search.solr.host%'
             port: '%siso_search.solr.port%'
             path: '%siso_search.solr.path%'
             core: admin
-            timeout: 30
         siso_econtent:
             host: '%siso_search.solr.host%'
             port: '%siso_search.solr.port%'
             path: '%siso_search.solr.path%'
             core: econtent
-            timeout: 30
         siso_econtent_back:
             host: '%siso_search.solr.host%'
             port: '%siso_search.solr.port%'
             path: '%siso_search.solr.path%'
             core: econtent_back
-            timeout: 30
 
     clients:
         default:
+            adapter_timeout: 30
             endpoints:
                 - default
+        siso_core_admin:
+            adapter_timeout: 30
+        siso_econtent:
+            adapter_timeout: 30
+        siso_econtent_back:
+            adapter_timeout: 30
         econtent:
             endpoints:
                 - siso_econtent

--- a/ibexa/commerce/4.0.x-dev/config/packages/nelmio_solarium.yaml
+++ b/ibexa/commerce/4.0.x-dev/config/packages/nelmio_solarium.yaml
@@ -5,9 +5,9 @@ nelmio_solarium:
             port: '%siso_search.solr.port%'
             path: '%siso_search.solr.path%'
             core: '%siso_search.solr.core%'
-            timeout: 30
 
     clients:
         default:
+            adapter_timeout: 30
             endpoints:
                 - default

--- a/ibexa/content/3.3.x-dev/config/packages/ezcommerce/ezcommerce_advanced.yaml
+++ b/ibexa/content/3.3.x-dev/config/packages/ezcommerce/ezcommerce_advanced.yaml
@@ -21,30 +21,33 @@ nelmio_solarium:
             port: '%siso_search.solr.port%'
             path: '%siso_search.solr.path%'
             core: '%siso_search.solr.core%'
-            timeout: 30
         siso_core_admin:
             host: '%siso_search.solr.host%'
             port: '%siso_search.solr.port%'
             path: '%siso_search.solr.path%'
             core: admin
-            timeout: 30
         siso_econtent:
             host: '%siso_search.solr.host%'
             port: '%siso_search.solr.port%'
             path: '%siso_search.solr.path%'
             core: econtent
-            timeout: 30
         siso_econtent_back:
             host: '%siso_search.solr.host%'
             port: '%siso_search.solr.port%'
             path: '%siso_search.solr.path%'
             core: econtent_back
-            timeout: 30
 
     clients:
         default:
+            adapter_timeout: 30
             endpoints:
                 - default
+        siso_core_admin:
+            adapter_timeout: 30
+        siso_econtent:
+            adapter_timeout: 30
+        siso_econtent_back:
+            adapter_timeout: 30
         econtent:
             endpoints:
                 - siso_econtent

--- a/ibexa/content/3.3.x-dev/config/packages/nelmio_solarium.yaml
+++ b/ibexa/content/3.3.x-dev/config/packages/nelmio_solarium.yaml
@@ -5,9 +5,9 @@ nelmio_solarium:
             port: '%siso_search.solr.port%'
             path: '%siso_search.solr.path%'
             core: '%siso_search.solr.core%'
-            timeout: 30
 
     clients:
         default:
+            adapter_timeout: 30
             endpoints:
                 - default

--- a/ibexa/content/4.0.x-dev/config/packages/ezcommerce/ezcommerce_advanced.yaml
+++ b/ibexa/content/4.0.x-dev/config/packages/ezcommerce/ezcommerce_advanced.yaml
@@ -21,30 +21,33 @@ nelmio_solarium:
             port: '%siso_search.solr.port%'
             path: '%siso_search.solr.path%'
             core: '%siso_search.solr.core%'
-            timeout: 30
         siso_core_admin:
             host: '%siso_search.solr.host%'
             port: '%siso_search.solr.port%'
             path: '%siso_search.solr.path%'
             core: admin
-            timeout: 30
         siso_econtent:
             host: '%siso_search.solr.host%'
             port: '%siso_search.solr.port%'
             path: '%siso_search.solr.path%'
             core: econtent
-            timeout: 30
         siso_econtent_back:
             host: '%siso_search.solr.host%'
             port: '%siso_search.solr.port%'
             path: '%siso_search.solr.path%'
             core: econtent_back
-            timeout: 30
 
     clients:
         default:
+            adapter_timeout: 30
             endpoints:
                 - default
+        siso_core_admin:
+            adapter_timeout: 30
+        siso_econtent:
+            adapter_timeout: 30
+        siso_econtent_back:
+            adapter_timeout: 30
         econtent:
             endpoints:
                 - siso_econtent

--- a/ibexa/content/4.0.x-dev/config/packages/nelmio_solarium.yaml
+++ b/ibexa/content/4.0.x-dev/config/packages/nelmio_solarium.yaml
@@ -5,9 +5,9 @@ nelmio_solarium:
             port: '%siso_search.solr.port%'
             path: '%siso_search.solr.path%'
             core: '%siso_search.solr.core%'
-            timeout: 30
 
     clients:
         default:
+            adapter_timeout: 30
             endpoints:
                 - default

--- a/ibexa/experience/3.3.x-dev/config/packages/ezcommerce/ezcommerce_advanced.yaml
+++ b/ibexa/experience/3.3.x-dev/config/packages/ezcommerce/ezcommerce_advanced.yaml
@@ -21,30 +21,33 @@ nelmio_solarium:
             port: '%siso_search.solr.port%'
             path: '%siso_search.solr.path%'
             core: '%siso_search.solr.core%'
-            timeout: 30
         siso_core_admin:
             host: '%siso_search.solr.host%'
             port: '%siso_search.solr.port%'
             path: '%siso_search.solr.path%'
             core: admin
-            timeout: 30
         siso_econtent:
             host: '%siso_search.solr.host%'
             port: '%siso_search.solr.port%'
             path: '%siso_search.solr.path%'
             core: econtent
-            timeout: 30
         siso_econtent_back:
             host: '%siso_search.solr.host%'
             port: '%siso_search.solr.port%'
             path: '%siso_search.solr.path%'
             core: econtent_back
-            timeout: 30
 
     clients:
         default:
+            adapter_timeout: 30
             endpoints:
                 - default
+        siso_core_admin:
+            adapter_timeout: 30
+        siso_econtent:
+            adapter_timeout: 30
+        siso_econtent_back:
+            adapter_timeout: 30
         econtent:
             endpoints:
                 - siso_econtent

--- a/ibexa/experience/3.3.x-dev/config/packages/nelmio_solarium.yaml
+++ b/ibexa/experience/3.3.x-dev/config/packages/nelmio_solarium.yaml
@@ -5,9 +5,9 @@ nelmio_solarium:
             port: '%siso_search.solr.port%'
             path: '%siso_search.solr.path%'
             core: '%siso_search.solr.core%'
-            timeout: 30
 
     clients:
         default:
+            adapter_timeout: 30
             endpoints:
                 - default

--- a/ibexa/experience/4.0.x-dev/config/packages/ezcommerce/ezcommerce_advanced.yaml
+++ b/ibexa/experience/4.0.x-dev/config/packages/ezcommerce/ezcommerce_advanced.yaml
@@ -21,30 +21,33 @@ nelmio_solarium:
             port: '%siso_search.solr.port%'
             path: '%siso_search.solr.path%'
             core: '%siso_search.solr.core%'
-            timeout: 30
         siso_core_admin:
             host: '%siso_search.solr.host%'
             port: '%siso_search.solr.port%'
             path: '%siso_search.solr.path%'
             core: admin
-            timeout: 30
         siso_econtent:
             host: '%siso_search.solr.host%'
             port: '%siso_search.solr.port%'
             path: '%siso_search.solr.path%'
             core: econtent
-            timeout: 30
         siso_econtent_back:
             host: '%siso_search.solr.host%'
             port: '%siso_search.solr.port%'
             path: '%siso_search.solr.path%'
             core: econtent_back
-            timeout: 30
 
     clients:
         default:
+            adapter_timeout: 30
             endpoints:
                 - default
+        siso_core_admin:
+            adapter_timeout: 30
+        siso_econtent:
+            adapter_timeout: 30
+        siso_econtent_back:
+            adapter_timeout: 30
         econtent:
             endpoints:
                 - siso_econtent

--- a/ibexa/experience/4.0.x-dev/config/packages/nelmio_solarium.yaml
+++ b/ibexa/experience/4.0.x-dev/config/packages/nelmio_solarium.yaml
@@ -5,9 +5,9 @@ nelmio_solarium:
             port: '%siso_search.solr.port%'
             path: '%siso_search.solr.path%'
             core: '%siso_search.solr.core%'
-            timeout: 30
 
     clients:
         default:
+            adapter_timeout: 30
             endpoints:
                 - default


### PR DESCRIPTION
Due to bumped solarium-related dependencies in https://github.com/ezsystems/ezcommerce-shop/pull/390, we need to remove the deprecated `timeout` parameter. Changes aim to be in-tact with upgrade instructions from the `NelmioSolariumBundle` itself: https://github.com/nelmio/NelmioSolariumBundle/blob/701db3f55f371e44804a0e241fa11357cfce1b82/UPGRADING.md#upgrading-from-v4x-to-v50.