### PR TITLE
[ibexa/all] Skip version 1.7.1 and 1.8.0 of webpack encore

### DIFF
--- a/ibexa/commerce/4.0.x-dev/encore/package.json
+++ b/ibexa/commerce/4.0.x-dev/encore/package.json
@@ -2,7 +2,7 @@
   "devDependencies": {
     "@hotwired/stimulus": "^3.0.0",
     "@symfony/stimulus-bridge": "^3.0.0",
-    "@symfony/webpack-encore": "^1.7.0",
+    "@symfony/webpack-encore": "<=1.7.0 || >1.8.0",
     "@babel/preset-react": "^7.0.0",
     "core-js": "^3.0.0",
     "regenerator-runtime": "^0.13.2",

--- a/ibexa/commerce/4.0.x-dev/encore/package.json
+++ b/ibexa/commerce/4.0.x-dev/encore/package.json
@@ -2,7 +2,7 @@
   "devDependencies": {
     "@hotwired/stimulus": "^3.0.0",
     "@symfony/stimulus-bridge": "^3.0.0",
-    "@symfony/webpack-encore": "<=1.7.0 || >1.8.0",
+    "@symfony/webpack-encore": "1.7.0 || >1.8.0",
     "@babel/preset-react": "^7.0.0",
     "core-js": "^3.0.0",
     "regenerator-runtime": "^0.13.2",

--- a/ibexa/content/4.0.x-dev/encore/package.json
+++ b/ibexa/content/4.0.x-dev/encore/package.json
@@ -2,7 +2,7 @@
   "devDependencies": {
     "@hotwired/stimulus": "^3.0.0",
     "@symfony/stimulus-bridge": "^3.0.0",
-    "@symfony/webpack-encore": "^1.7.0",
+    "@symfony/webpack-encore": "<=1.7.0 || >1.8.0",
     "@babel/preset-react": "^7.0.0",
     "core-js": "^3.0.0",
     "regenerator-runtime": "^0.13.2",

--- a/ibexa/content/4.0.x-dev/encore/package.json
+++ b/ibexa/content/4.0.x-dev/encore/package.json
@@ -2,7 +2,7 @@
   "devDependencies": {
     "@hotwired/stimulus": "^3.0.0",
     "@symfony/stimulus-bridge": "^3.0.0",
-    "@symfony/webpack-encore": "<=1.7.0 || >1.8.0",
+    "@symfony/webpack-encore": "1.7.0 || >1.8.0",
     "@babel/preset-react": "^7.0.0",
     "core-js": "^3.0.0",
     "regenerator-runtime": "^0.13.2",

--- a/ibexa/experience/4.0.x-dev/encore/package.json
+++ b/ibexa/experience/4.0.x-dev/encore/package.json
@@ -2,7 +2,7 @@
   "devDependencies": {
     "@hotwired/stimulus": "^3.0.0",
     "@symfony/stimulus-bridge": "^3.0.0",
-    "@symfony/webpack-encore": "^1.7.0",
+    "@symfony/webpack-encore": "<=1.7.0 || >1.8.0",
     "@babel/preset-react": "^7.0.0",
     "core-js": "^3.0.0",
     "regenerator-runtime": "^0.13.2",

--- a/ibexa/experience/4.0.x-dev/encore/package.json
+++ b/ibexa/experience/4.0.x-dev/encore/package.json
@@ -2,7 +2,7 @@
   "devDependencies": {
     "@hotwired/stimulus": "^3.0.0",
     "@symfony/stimulus-bridge": "^3.0.0",
-    "@symfony/webpack-encore": "<=1.7.0 || >1.8.0",
+    "@symfony/webpack-encore": "1.7.0 || >1.8.0",
     "@babel/preset-react": "^7.0.0",
     "core-js": "^3.0.0",
     "regenerator-runtime": "^0.13.2",

--- a/ibexa/oss/4.0.x-dev/encore/package.json
+++ b/ibexa/oss/4.0.x-dev/encore/package.json
@@ -2,7 +2,7 @@
   "devDependencies": {
     "@hotwired/stimulus": "^3.0.0",
     "@symfony/stimulus-bridge": "^3.0.0",
-    "@symfony/webpack-encore": "<=1.7.0 || >1.8.0",
+    "@symfony/webpack-encore": "1.7.0 || >1.8.0",
     "core-js": "^3.0.0",
     "regenerator-runtime": "^0.13.2",
     "webpack-notifier": "^1.6.0",

--- a/ibexa/oss/4.0.x-dev/encore/package.json
+++ b/ibexa/oss/4.0.x-dev/encore/package.json
@@ -2,7 +2,7 @@
   "devDependencies": {
     "@hotwired/stimulus": "^3.0.0",
     "@symfony/stimulus-bridge": "^3.0.0",
-    "@symfony/webpack-encore": "^1.7.0",
+    "@symfony/webpack-encore": "<=1.7.0 || >1.8.0",
     "core-js": "^3.0.0",
     "regenerator-runtime": "^0.13.2",
     "webpack-notifier": "^1.6.0",


### PR DESCRIPTION
This is a temporary fix for the missing 'eslint-webpack-plugin' dependency introduced in webpack-encore 1.7.1 and 1.8.0. 
Fix for unblocking CI and Nightly.

The fix should be reverted after the issue is solved https://github.com/symfony/webpack-encore/issues/1075