### PR TITLE
[ibexa/all] Skip version 1.7.1 and 1.8.0 of webpack encore

### DIFF
--- a/ibexa/commerce/3.3.x-dev/encore/package.json
+++ b/ibexa/commerce/3.3.x-dev/encore/package.json
@@ -2,7 +2,7 @@
   "devDependencies": {
     "@hotwired/stimulus": "^3.0.0",
     "@symfony/stimulus-bridge": "^3.0.0",
-    "@symfony/webpack-encore": "^1.7.0",
+    "@symfony/webpack-encore": "1.7.0 || >1.8.0",
     "@babel/preset-react": "^7.0.0",
     "core-js": "^3.0.0",
     "regenerator-runtime": "^0.13.2",

--- a/ibexa/content/3.3.x-dev/encore/package.json
+++ b/ibexa/content/3.3.x-dev/encore/package.json
@@ -2,7 +2,7 @@
   "devDependencies": {
     "@hotwired/stimulus": "^3.0.0",
     "@symfony/stimulus-bridge": "^3.0.0",
-    "@symfony/webpack-encore": "^1.7.0",
+    "@symfony/webpack-encore": "1.7.0 || >1.8.0",
     "@babel/preset-react": "^7.0.0",
     "core-js": "^3.0.0",
     "regenerator-runtime": "^0.13.2",

--- a/ibexa/experience/3.3.x-dev/encore/package.json
+++ b/ibexa/experience/3.3.x-dev/encore/package.json
@@ -2,7 +2,7 @@
   "devDependencies": {
     "@hotwired/stimulus": "^3.0.0",
     "@symfony/stimulus-bridge": "^3.0.0",
-    "@symfony/webpack-encore": "^1.7.0",
+    "@symfony/webpack-encore": "1.7.0 || >1.8.0",
     "@babel/preset-react": "^7.0.0",
     "core-js": "^3.0.0",
     "regenerator-runtime": "^0.13.2",

--- a/ibexa/oss/3.3.x-dev/encore/package.json
+++ b/ibexa/oss/3.3.x-dev/encore/package.json
@@ -2,7 +2,7 @@
   "devDependencies": {
     "@hotwired/stimulus": "^3.0.0",
     "@symfony/stimulus-bridge": "^3.0.0",
-    "@symfony/webpack-encore": "^1.7.0",
+    "@symfony/webpack-encore": "1.7.0 || >1.8.0",
     "@babel/preset-react": "^7.0.0",
     "core-js": "^3.0.0",
     "regenerator-runtime": "^0.13.2",


### PR DESCRIPTION
Follow-up for https://github.com/ibexa/recipes/pull/71 , but for v3.3