### PR TITLE
Added Symfony serverless workflows

### DIFF
--- a/.github/workflows/flex-update-achived.yml
+++ b/.github/workflows/flex-update-achived.yml
@@ -1,0 +1,7 @@
+name: Update Flex Archives
+
+on: [workflow_dispatch]
+
+jobs:
+    call-flex-update:
+        uses: symfony/recipes/.github/workflows/callable-flex-update-archived.yml@main

--- a/.github/workflows/flex-update.yml
+++ b/.github/workflows/flex-update.yml
@@ -1,0 +1,16 @@
+name: Update Flex endpoint
+
+on:
+    push:
+        branches:
+            - master
+
+defaults:
+    run:
+        shell: bash
+
+jobs:
+    call-flex-update:
+        uses: symfony/recipes/.github/workflows/callable-flex-update.yml@main
+        with:
+            branch: master


### PR DESCRIPTION
Resources:
https://symfony.com/doc/5.4/setup/flex_private_recipes.html
https://symfony.com/blog/symfony-flex-is-going-serverless

Relevant part:
> The JSON files are [stored in this repository](https://github.com/symfony/recipes/tree/flex/main) and are generated by
> GitHub Actions [using this script](https://github.com/symfony/recipes/blob/master/.github/workflows/flex-endpoint.yml) > thanks to a [custom recipe checker tool](https://github.com/symfony-tools/recipes-checker). The existing Flex server 
> endpoint will keep working for some time as a legacy service for applications that haven't been updated yet.

This PR adds the workflows used in `symfony/recipes` repository:
1) Generating recipes structure - flex-update.yml

https://github.com/symfony/recipes/blob/master/.github/workflows/flex-update.yml
It calls this workflow: https://github.com/symfony/recipes/blob/main/.github/workflows/callable-flex-update.yml

which parses the recipes and creates proper files so that they can be accessed by Flex - it's pushed to the `flex/main` branch.

You can see that Symfony adds an additional argument, versions_json: https://github.com/symfony/recipes/blob/master/.github/workflows/flex-update.yml#L13-L17 This file (https://github.com/symfony/recipes/blob/master/.github/versions.json#L8 ) is used only for Symfony packages and automatically defines aliases for their packages (see: https://github.com/symfony-tools/recipes-checker/blob/86f5d7f8c12b8fa3faeadc5a5652aba1b2e369d2/src/GenerateFlexEndpointCommand.php#L44-L54)

2) Creating a recipes archive

https://github.com/symfony/recipes/blob/master/.github/workflows/flex-update-achived.yml

This is required for the `recipes:update` command to work. See:
https://github.com/symfony/flex/issues/857
https://github.com/symfony/recipes/pull/1038
https://github.com/symfony-tools/recipes-checker/pull/3
https://github.com/symfony/flex/pull/845

Symfony has chosen manual trigger for now - this is fine, because it's a fallback in case something goes wrong in the update workflow and allos to rebuild the archive if needed. It's not needed on every push, because the archive should be updated during the update workflow (see "How it works" in https://github.com/symfony/flex/pull/845 - https://github.com/symfony/recipes/pull/1037 is the relevant PR that includes it in the `flex-update` workflow.

Other changes that are needed:
1) The `--force` switch does not work for the official recipes as we're used to, see https://github.com/symfony/flex/pull/702 (and the updated --force description: https://github.com/symfony/flex/pull/714/files)

To execute the recipe once again we need to use the `--force` option *combined* with `--reset` option.
PR: https://github.com/symfony/flex/pull/795

So, we will have to replace the mentions of `composer recipes:install <edition> --force` in manual installation doc with `composer recipes:install <edition> --force --reset`. Same for nightly and other tools.

2) For PHP 8/8.1 we need https://github.com/ibexa/oss/pull/44 - otherwise the downgrade that happens during the instalation process corrupts the instalation.

### Migrations process
1) We merge these PRs:
https://github.com/ibexa/recipes/pull/99
https://github.com/ibexa/oss/pull/44
2) We can test the endpoint locally, by running:
```
composer config extra.symfony.endpoint "https://api.github.com/repos/ibexa/recipes/contents/index.json?ref=flex/main"
```
3) We set a redirect from `https://flex.ibexa.co` to `https://api.github.com/repos/mnocon/recipes/contents/index.json?ref=flex/main` - this way we don't have to change the value in https://github.com/ibexa/website-skeleton/blob/3.3/composer.json#L98

We can do 1 and 2 right now, to test things - these steps are just preparation, only after step 3 our current solution (private Flex server) can be disabled and the new one will start working. 

### Testing process
If you'd like to see it in action locally you can use:
https://github.com/mnocon/website-skeleton/ (which uses our new endpoint endpoint: https://github.com/ibexa/website-skeleton/blob/3.3/composer.json#L98).
Install running:
```
composer create-project mnocon/website-skeleton:^4.0.x-dev --repository='{"type": "vcs","url": "https://github.com/mnocon/website-skeleton"}'
```

Generated recipes:
https://github.com/ibexa/recipes/tree/flex/main
https://github.com/ibexa/recipes/blob/flex/main/index.json

Remember about the `--reset` flag during manual installation.


