### PR TITLE
Commerce 4.4 and 4.5: Remove user_registration.group_id wrong ID

### DIFF
--- a/ibexa/commerce/4.4/config/packages/ibexa.yaml
+++ b/ibexa/commerce/4.4/config/packages/ibexa.yaml
@@ -125,7 +125,6 @@ ibexa:
             user_content_type_identifier: ['customer']
             user_registration:
                 user_type_identifier: 'customer'
-                group_id: 57
 
         corporate_group:
             languages: [eng-GB]

--- a/ibexa/commerce/4.5/config/packages/ibexa.yaml
+++ b/ibexa/commerce/4.5/config/packages/ibexa.yaml
@@ -125,7 +125,6 @@ ibexa:
             user_content_type_identifier: ['customer']
             user_registration:
                 user_type_identifier: 'customer'
-                group_id: 57
 
         corporate_group:
             languages: [eng-GB]


### PR DESCRIPTION
Between 4.3 and 4.4+, the content tree has changed:
- In 4.3.5, ContentId 57 is "Private customers" user group;
- In 4.4.2 and 4.5.0-beta2, ContentId 57 is "Tags" and there isn't a "Private customers" user group anymore.

The quickest fix is to just remove it to create new customers in the global default user group.